### PR TITLE
Add R/W flag to openfile interface

### DIFF
--- a/lib/file.ml
+++ b/lib/file.ml
@@ -14,12 +14,13 @@
 
 let use_unbuffered = ref false
 
-external openfile_unbuffered: string -> int -> Unix.file_descr = "stub_openfile_direct"
+external openfile_unbuffered: string -> bool -> int -> Unix.file_descr = "stub_openfile_direct"
 
-let openfile_buffered filename mode = Unix.openfile filename [ Unix.O_RDWR ] mode
+let openfile_buffered filename rw perm =
+	Unix.openfile filename ([ if rw then Unix.O_RDWR else Unix.O_RDONLY ]) perm
 
-let openfile filename mode =
-  (if !use_unbuffered then openfile_unbuffered else openfile_buffered) filename mode
+let openfile filename rw perm =
+  (if !use_unbuffered then openfile_unbuffered else openfile_buffered) filename rw perm
 
 external blkgetsize64: string -> int64 = "stub_blkgetsize64"
 

--- a/lib/file.mli
+++ b/lib/file.mli
@@ -15,7 +15,7 @@
 val use_unbuffered: bool ref
 (** if set to true we will use unbuffered I/O via O_DIRECT *)
 
-val openfile: string -> int -> Unix.file_descr
+val openfile: string -> bool -> int -> Unix.file_descr
 (** [openfile filename mode] opens [filename] read/write using
     the current global buffering mode *)
 

--- a/lib/odirect_stubs.c
+++ b/lib/odirect_stubs.c
@@ -32,15 +32,21 @@
 extern void uerror(char *cmdname, value cmdarg);
 #define Nothing ((value) 0)
 
-CAMLprim value stub_openfile_direct(value filename, value mode){
-  CAMLparam2(filename, mode);
+CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
+  CAMLparam3(filename, rw, perm);
   CAMLlocal1(result);
   int fd;
 
   const char *filename_c = strdup(String_val(filename));
 
   enter_blocking_section();
-  fd = open(filename_c, O_RDWR | O_DIRECT, Int_val(mode));
+  int flags = O_DIRECT;
+  if (Bool_val(rw)) {
+    flags |= O_RDWR;
+  } else {
+    flags |= O_RDONLY;
+  }
+  fd = open(filename_c, flags, Int_val(perm));
   leave_blocking_section();
 
   free((void*)filename_c);

--- a/lib/patterns_lwt.ml
+++ b/lib/patterns_lwt.ml
@@ -148,7 +148,7 @@ let verify t contents =
     write_stream fd stream >>= fun _ ->
     Fd.close fd >>= fun () ->
     (* Check the contents look correct *)
-    Vhd_IO.openfile filename >>= fun t' ->
+    Vhd_IO.openfile filename false >>= fun t' ->
     check_written_sectors t' contents >>= fun () ->
     check_raw_stream_contents ~allow_empty:true t' contents >>= fun () ->
     Vhd_IO.close t' >>= fun () ->
@@ -159,7 +159,7 @@ let verify t contents =
     write_stream fd stream >>= fun _ ->
     Fd.close fd >>= fun () ->
     (* Check the contents look correct *)
-    Vhd_IO.openfile filename >>= fun t' ->
+    Vhd_IO.openfile filename false >>= fun t' ->
     check_written_sectors t' contents >>= fun () ->
     check_raw_stream_contents ~allow_empty:true t' contents >>= fun () ->
     Vhd_IO.close t'

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -45,7 +45,7 @@ module type IO = sig
   include RW with type handle := fd
 
   val exists: string -> bool t
-  val openfile: string -> fd t
+  val openfile: string -> bool -> fd t
   val fsync: fd -> unit
   val create: string -> fd t
   val close: fd -> unit t

--- a/lib/vhd.mli
+++ b/lib/vhd.mli
@@ -337,7 +337,7 @@ module Make : functor (File : S.IO) -> sig
   open File
 
   module Vhd_IO : sig
-    val openfile : ?path:string list -> string -> fd Vhd.t t
+    val openfile : ?path:string list -> string -> bool -> fd Vhd.t t
     (** [openfile ?path filename] reads the vhd metadata from [filename] (and other
         files on the path from [filename] to the root of the tree). If [filename]
         or any of the parent locators have relative paths, then they will be
@@ -379,7 +379,7 @@ module Make : functor (File : S.IO) -> sig
   end
 
   module Raw_IO : sig
-    val openfile : string -> fd Raw.t t
+    val openfile : string -> bool -> fd Raw.t t
     (** [openfile filename] opens a raw-format file [filename] *)
 
     val close : fd Raw.t -> unit t

--- a/lib/vhd_lwt.ml
+++ b/lib/vhd_lwt.ml
@@ -42,8 +42,8 @@ module Fd = struct
     lock: Lwt_mutex.t;
   }
 
-  let openfile filename =
-    let unix_fd = File.openfile filename 0o644 in
+  let openfile filename rw =
+    let unix_fd = File.openfile filename rw 0o644 in
     let fd = Lwt_unix.of_unix_file_descr unix_fd in
     let lock = Lwt_mutex.create () in
     return { fd; filename; lock }
@@ -61,7 +61,7 @@ module Fd = struct
     lwt fd = Lwt_unix.openfile filename [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_TRUNC ] 0o644 in
     lwt () = Lwt_unix.close fd in
     (* Then re-open using our new API *)
-    openfile filename
+    openfile filename true
 
   let close t = Lwt_unix.close t.fd
 

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -43,7 +43,7 @@ let make_new_filename =
 let check_empty_disk size =
   let filename = make_new_filename () in
   Vhd_IO.create_dynamic ~filename ~size () >>= fun vhd ->
-  Vhd_IO.openfile filename >>= fun vhd' ->
+  Vhd_IO.openfile filename false >>= fun vhd' ->
   assert_equal ~printer:Header.to_string ~cmp:Header.equal vhd.Vhd.header vhd'.Vhd.header;
   assert_equal ~printer:Footer.to_string vhd.Vhd.footer vhd'.Vhd.footer;
   assert_equal ~printer:BAT.to_string ~cmp:BAT.equal vhd.Vhd.bat vhd'.Vhd.bat;
@@ -56,7 +56,7 @@ let check_empty_snapshot size =
   Vhd_IO.create_dynamic ~filename ~size () >>= fun vhd ->
   let filename = make_new_filename () in
   Vhd_IO.create_difference ~filename ~parent:vhd () >>= fun vhd' ->
-  Vhd_IO.openfile filename >>= fun vhd'' ->
+  Vhd_IO.openfile filename false >>= fun vhd'' ->
   assert_equal ~printer:Header.to_string ~cmp:Header.equal vhd'.Vhd.header vhd''.Vhd.header;
   assert_equal ~printer:Footer.to_string vhd'.Vhd.footer vhd''.Vhd.footer;
   assert_equal ~printer:BAT.to_string ~cmp:BAT.equal vhd'.Vhd.bat vhd''.Vhd.bat;


### PR DESCRIPTION
Files should not be opened RW by default and parents of VHD files can always be
opened RO.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
