### PR TITLE
vhd: rename 'openfile' to 'openchain'; add 'openfile'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ trunk (unreleased)
 * vhd: rename Vhd_input.hybrid -> Hybrid_input.raw
 * vhd: add Hybrid_input.vhd to output vhd-formatted data
 * vhd: fix stream size calculation, so progress reports (bars?) will be more accurate
+* vhd: rename 'openfile' to 'openchain' to reflect that it opens an entire chain,
+  or fails trying
+* vhd: add 'openfile' which only opens a single file
 
 0.6.4 (2013-11-06)
 * vhd: we expect parent locators to have prefix "file://", rather than "file://./"

--- a/lib/patterns_lwt.ml
+++ b/lib/patterns_lwt.ml
@@ -148,7 +148,7 @@ let verify t contents =
     write_stream fd stream >>= fun _ ->
     Fd.close fd >>= fun () ->
     (* Check the contents look correct *)
-    Vhd_IO.openfile filename false >>= fun t' ->
+    Vhd_IO.openchain filename false >>= fun t' ->
     check_written_sectors t' contents >>= fun () ->
     check_raw_stream_contents ~allow_empty:true t' contents >>= fun () ->
     Vhd_IO.close t' >>= fun () ->
@@ -159,7 +159,7 @@ let verify t contents =
     write_stream fd stream >>= fun _ ->
     Fd.close fd >>= fun () ->
     (* Check the contents look correct *)
-    Vhd_IO.openfile filename false >>= fun t' ->
+    Vhd_IO.openchain filename false >>= fun t' ->
     check_written_sectors t' contents >>= fun () ->
     check_raw_stream_contents ~allow_empty:true t' contents >>= fun () ->
     Vhd_IO.close t'

--- a/lib/vhd.mli
+++ b/lib/vhd.mli
@@ -365,11 +365,15 @@ module From_file : functor (F : S.FILE) -> sig
   open F
 
   module Vhd_IO : sig
-    val openfile : ?path:string list -> string -> bool -> fd Vhd.t t
-    (** [openfile ?path filename] reads the vhd metadata from [filename] (and other
+    val openchain : ?path:string list -> string -> bool -> fd Vhd.t t
+    (** [openchain ?path filename] reads the vhd metadata from [filename] (and other
         files on the path from [filename] to the root of the tree). If [filename]
         or any of the parent locators have relative paths, then they will be
         searched for on the ?path. *)
+
+    val openfile : string -> bool -> fd Vhd.t t
+    (** [openfile filename] reads the vhd metadata from [filename], but not any
+        other files on the path to the root of the tree. *)
 
     val close : fd Vhd.t -> unit t
     (** [close t] frees all resources associated with [t] *)

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -44,7 +44,7 @@ let make_new_filename =
 let check_empty_disk size =
   let filename = make_new_filename () in
   Vhd_IO.create_dynamic ~filename ~size () >>= fun vhd ->
-  Vhd_IO.openfile filename false >>= fun vhd' ->
+  Vhd_IO.openchain filename false >>= fun vhd' ->
   assert_equal ~printer:Header.to_string ~cmp:Header.equal vhd.Vhd.header vhd'.Vhd.header;
   assert_equal ~printer:Footer.to_string vhd.Vhd.footer vhd'.Vhd.footer;
   assert_equal ~printer:BAT.to_string ~cmp:BAT.equal vhd.Vhd.bat vhd'.Vhd.bat;
@@ -57,7 +57,7 @@ let check_empty_snapshot size =
   Vhd_IO.create_dynamic ~filename ~size () >>= fun vhd ->
   let filename = make_new_filename () in
   Vhd_IO.create_difference ~filename ~parent:vhd () >>= fun vhd' ->
-  Vhd_IO.openfile filename false >>= fun vhd'' ->
+  Vhd_IO.openchain filename false >>= fun vhd'' ->
   assert_equal ~printer:Header.to_string ~cmp:Header.equal vhd'.Vhd.header vhd''.Vhd.header;
   assert_equal ~printer:Footer.to_string vhd'.Vhd.footer vhd''.Vhd.footer;
   assert_equal ~printer:BAT.to_string ~cmp:BAT.equal vhd'.Vhd.bat vhd''.Vhd.bat;
@@ -74,7 +74,7 @@ let check_parent_parent_dir () =
   (try Unix.mkdir leaf_dir 0o0755 with _ -> ());
   Vhd_IO.create_difference ~filename:leaf_path ~parent:vhd ~relative_path:true () >>= fun vhd' ->
   (* Make sure we can open the leaf *)
-  Vhd_IO.openfile leaf_path false >>= fun vhd'' ->
+  Vhd_IO.openchain leaf_path false >>= fun vhd'' ->
   Vhd_IO.close vhd'' >>= fun () ->
   Vhd_IO.close vhd' >>= fun () ->
   Vhd_IO.close vhd
@@ -85,7 +85,7 @@ let check_readonly () =
   Vhd_IO.create_dynamic ~filename ~size:0L () >>= fun vhd ->
   Vhd_IO.close vhd >>= fun () ->
   Unix.chmod filename 0o444;
-  Vhd_IO.openfile filename false >>= fun vhd ->
+  Vhd_IO.openchain filename false >>= fun vhd ->
   Vhd_IO.close vhd
 
 let fill_sector_with pattern =


### PR DESCRIPTION
openchain: opens every vhd file on a path to the root or
  fails trying

openfile: opens only the named vhd file

Signed-off-by: David Scott dave.scott@eu.citrix.com
