### PR TITLE
write: compute all the updates we need and perform them in parallel

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -106,6 +106,4 @@ let read t offset bufs = match t.vhd with
 
 let write t offset bufs = match t.vhd with
   | None -> return (`Error `Disconnected)
-  | Some vhd ->
-    forall_sectors (Vhd_IO.write_sector vhd) offset bufs >>= fun () ->
-    return (`Ok ())
+  | Some vhd -> Vhd_IO.write vhd offset bufs >>= fun () -> return (`Ok ())

--- a/lib/f.mli
+++ b/lib/f.mli
@@ -264,6 +264,14 @@ module Bitmap : sig
 
 end
 
+module Bitmap_cache : sig
+  type t = {
+    cache: (int * Bitmap.t) option ref; (* effective only for streaming *)
+    all_zeroes: Cstruct.t;
+    all_ones: Cstruct.t;
+  }
+end
+
 module Sector : sig
   type t = Cstruct.t
   val dump : Cstruct.t -> unit
@@ -279,7 +287,7 @@ module Vhd : sig
     parent : 'a t option;
     bat : BAT.t;
     batmap : (Batmap_header.t * Batmap.t) option;
-    bitmap_cache : (int * Bitmap.t) option ref;
+    bitmap_cache : Bitmap_cache.t
   }
 
   val check_overlapping_blocks : 'a t -> unit
@@ -408,8 +416,8 @@ module From_file : functor (F : S.FILE) -> sig
         (i.e. the data should be interpreted as zeros) the function returns false
         but does not write into [buffer]. *)
 
-    val write_sector : fd Vhd.t -> int64 -> Cstruct.t -> unit t
-    (** [write_sector t sector data] writes [data] at [sector] in [t] and
+    val write : fd Vhd.t -> int64 -> Cstruct.t list -> unit t
+    (** [write t sector data] writes [data] at [sector] in [t] and
         updates all file metadata to preserve consistency. *)
   end
 

--- a/lib/iO.ml
+++ b/lib/iO.ml
@@ -15,8 +15,6 @@
 let debug_io = ref false
 
 let complete name offset op fd buffer =
-  if !debug_io
-  then Printf.fprintf stderr "%s offset=%s length=%d\n%!" name (match offset with Some x -> Int64.to_string x | None -> "None") (Cstruct.len buffer);
   let open Lwt in
   let ofs = buffer.Cstruct.off in
   let len = buffer.Cstruct.len in
@@ -29,6 +27,13 @@ let complete name offset op fd buffer =
     then return acc'
     else loop acc' fd buf (ofs + n) len' in
   loop 0 fd buf ofs len >>= fun n ->
+  if !debug_io
+  then Printf.fprintf stderr "%s offset=%s buffer = [%s](%d)\n%!"
+    name (match offset with Some x -> Int64.to_string x | None -> "None")
+    (if Cstruct.len buffer > 16
+     then (String.escaped (Cstruct.(to_string (sub buffer 0 13)))) ^ "..."
+     else (String.escaped (Cstruct.to_string buffer)))
+    (Cstruct.len buffer);
   if n = 0 && len <> 0
   then fail End_of_file
   else return ()

--- a/lib_test/parse_test.ml
+++ b/lib_test/parse_test.ml
@@ -163,7 +163,7 @@ let execute state = function
     | None -> failwith "no vhd open" in
     begin match absolute_sector_of vhd position with
       | Some sector ->
-        Vhd_IO.write_sector vhd sector data >>= fun () ->
+        Vhd_IO.write vhd sector [ data ] >>= fun () ->
         (* Overwrite means we forget any previous contents *)
         let contents = List.filter (fun (x, _) -> x <> sector) state.contents in
         return { state with contents = (sector, data) :: contents }


### PR DESCRIPTION
When a single request comes in with a set of buffers (e.g. from a large
sequential I/O) we partition the request into unit which align with
the underlying file block structure, and then write almost everything in
parallel. The only metadata which is deliberately left until the end
is the BAT, which has to point to a well-formed block.

Note if we crash half-way through, an arbitrary subset of the [bufs]
will have been committed, but the file metadata will be intact.

Note we still write the whole BAT every time we allocate a block.
We should keep track of which sectors need flushing.

Signed-off-by: David Scott dave.scott@eu.citrix.com
