### PR TITLE
comply with mirage3 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 sudo: false
 env:
  global:
+   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
    - PACKAGE="vhd-format"
  matrix:
    - DISTRO=debian-stable OCAML_VERSION=4.03.0

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -18,8 +18,6 @@ open M
 
 type 'a io = 'a Lwt.t
 
-type id = string
-
 type error = [
   | `Unknown of string
   | `Unimplemented
@@ -38,10 +36,8 @@ type info = {
 type t = {
   mutable vhd: IO.fd Vhd.F.Vhd.t option;
   info: info;
-  id: id;
+  id: string;
 }
-
-let id t = t.id
 
 let connect path =
   Lwt_unix.LargeFile.stat path >>= fun _ ->

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -44,13 +44,7 @@ type t = {
 let id t = t.id
 
 let connect path =
-  Lwt.catch
-    (fun () -> Lwt_unix.LargeFile.stat path >>= fun _ -> return true)
-    (fun _ -> return false)
-  >>= fun exists ->
-  if not exists
-  then return (`Error (`Unknown (Printf.sprintf "File does not exist: %s" path)))
-  else
+  Lwt_unix.LargeFile.stat path >>= fun _ ->
   Lwt.catch
     (fun () -> Lwt_unix.access path [ Lwt_unix.W_OK ] >>= fun () -> return true)
     (fun _ -> return false)
@@ -61,7 +55,7 @@ let connect path =
   let size_sectors = Int64.div vhd.Vhd.footer.Footer.current_size 512L in
   let info = { read_write; sector_size; size_sectors } in
   let id = path in
-  return (`Ok { vhd = Some vhd; info; id })
+  return ({ vhd = Some vhd; info; id })
 
 let disconnect t = match t.vhd with
   | None -> return ()

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -15,4 +15,4 @@
 include V1_LWT.BLOCK
   with type id = string
 
-val connect : string -> [`Ok of t | `Error of error] io
+val connect : string -> t io

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -13,6 +13,5 @@
  *)
 
 include V1_LWT.BLOCK
-  with type id = string
 
 val connect : string -> t io


### PR DESCRIPTION
* Remove `id` type, which will not be required by `mirage-types` 3.
* `connect` should no longer return an `Ok | Error` variant but rather return the result directly.