### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/lib/block.mli
+++ b/lib/block.mli
@@ -12,6 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 
-include V1_LWT.BLOCK
+include Mirage_types_lwt.BLOCK
 
 val connect : string -> t io


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.