### PR TITLE
Fix exception handling in lwt really_{read,write}

### DIFF
--- a/vhd_format_lwt/iO.ml
+++ b/vhd_format_lwt/iO.ml
@@ -95,7 +95,11 @@ module Fd = struct
           fail e
         | End_of_file as e ->
           Printf.fprintf stderr "really_read offset = %Ld len = %d: End_of_file\n%!" offset (Cstruct.len buf);
-          fail e 
+          fail e
+        | e ->
+          Printf.fprintf stderr "really_read offset = %Ld len = %d: %s\n%!"
+            offset (Cstruct.len buf) (Printexc.to_string e);
+          fail e
         )
       )
 
@@ -116,7 +120,11 @@ module Fd = struct
           fail e
         | End_of_file as e ->
           Printf.fprintf stderr "really_write offset = %Ld len = %d: End_of_file\n%!" offset (Cstruct.len buf);
-          fail e 
+          fail e
+        | e ->
+          Printf.fprintf stderr "really_write offset = %Ld len = %d: %s\n%!"
+            offset (Cstruct.len buf) (Printexc.to_string e);
+          fail e
         )
       )
 


### PR DESCRIPTION
The `really_read` and `really_write` functions in iO.ml (currently in
`vhd_format_lwt/`) were changed to drop their use of `lwt_try` in d2c6405c.
Instead, the code now uses `Lwt.catch` directly.

The camlp4 extension for `lwt_try` automatically adds a default exception
handler of `| exn -> Lwt.fail exn` to the `with` clause. However, this was not
added in the above commit. For exceptions that aren't explicitly matched by the
handler that is passed to `Lwt.catch`, this leads to `Match_failure` exceptions
being raised rather than the actual exception being passed up with `Lwt.fail`.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>