### PR TITLE
VDI I/O error while import large size VDI (> 1TB)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,4 @@ env:
    - PACKAGE=vhd-format DISTRO=debian-stable OCAML_VERSION=4.04.2
    - PACKAGE=vhd-format-lwt DISTRO=ubuntu-16.04 OCAML_VERSION=4.03.0
    - PACKAGE=vhd-format-lwt DISTRO=debian-stable OCAML_VERSION=4.04.2
-   - PACKAGE=vhd-format-lwt DISTRO=centos-7 OCAML_VERSION=4.05.0
    - PACKAGE=vhd-format-lwt DISTRO=alpine OCAML_VERSION=4.06.0
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: PACKAGE=vhd-format-lwt DISTRO=alpine OCAML_VERSION=4.06.0

--- a/disk/jbuild
+++ b/disk/jbuild
@@ -4,4 +4,4 @@
    (cstruct
     lwt
     lwt.unix))
-  (preprocess (pps (lwt.ppx)))))
+  (preprocess (pps (lwt_ppx)))))

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -12,6 +12,7 @@ build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "cstruct"
+  "integers"
   "lwt" {>= "2.4.3"}
   "mirage-block"
   "mirage-types-lwt" {>= "3.0.0"}

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -13,11 +13,12 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "cstruct"
   "integers"
-  "lwt" {>= "2.4.3"}
+  "lwt" {>= "3.2.0"}
   "mirage-block"
   "mirage-types-lwt" {>= "3.0.0"}
   "ounit"
   "vhd-format"
+  "lwt_ppx"
   "io-page-unix" {test}
   "jbuilder" {build}
 ]

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -15,6 +15,7 @@ depends: [
   "io-page"
   "rresult"
   "uuidm"
+  "lwt_ppx"
   "jbuilder" {build}
   "ppx_cstruct" {build}
 ]

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -11,6 +11,7 @@ dev-repo: "git://github.com/mirage/ocaml-vhd"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "cstruct" {>= "1.9"}
+  "integers"
   "io-page"
   "rresult"
   "uuidm"

--- a/vhd_format/f.mli
+++ b/vhd_format/f.mli
@@ -231,7 +231,7 @@ module BAT : sig
   val set: t -> int -> int32 -> unit
   (** [set t i j] sets the [i]th entry to [j] *)
 
-  val fold: (int -> int32 -> 'a -> 'a) -> t -> 'a -> 'a
+  val fold: (int -> int64 -> 'a -> 'a) -> t -> 'a -> 'a
   (** [fold f t initial] folds [f] across all valid entries *)
 
   val length: t -> int

--- a/vhd_format/jbuild
+++ b/vhd_format/jbuild
@@ -3,6 +3,7 @@
   (public_name vhd-format)
   (libraries
    (cstruct
+    integers
     io-page
     rresult
     uuidm))

--- a/vhd_format_lwt/jbuild
+++ b/vhd_format_lwt/jbuild
@@ -4,7 +4,6 @@
   (libraries
    (cstruct
     lwt
-    lwt.preemptive
     lwt.unix
     mirage-block
     mirage-types-lwt

--- a/vhd_format_lwt_test/jbuild
+++ b/vhd_format_lwt_test/jbuild
@@ -9,7 +9,7 @@
       oUnit
       vhd-format
       vhd_format_lwt))
-   (preprocess (pps (lwt.ppx)))))
+   (preprocess (pps (lwt_ppx)))))
 
 (alias
   ((name   runtest)


### PR DESCRIPTION
While importing large size VDI (>1TB), error will happen due to an overflow for getting virtual address through BAT.
The fix will use `integers` to convert signed one to unsigned.
Signed-off-by: Min Li <min.li1@citrix.com>