### PR TITLE
Fix string escaping in code generator

### DIFF
--- a/disk/disk.ml
+++ b/disk/disk.ml
@@ -59,7 +59,8 @@ let print_ocaml out t =
     (fun ofs cstr ->
       let buf = Bytes.make (Cstruct.len cstr) '\000' in
       Cstruct.blit_to_bytes cstr 0 buf 0 (Cstruct.len cstr);
-      Printf.fprintf out "  t := Disk.write_string !t %LdL \"%s\";\n" ofs (buf |> Bytes.to_string)
+      Printf.fprintf out "  t := Disk.write_string !t %LdL \"%s\";\n"
+        ofs (buf |> Bytes.to_string |> String.escaped)
     ) t;
   Printf.fprintf out "  !t\n"
 


### PR DESCRIPTION
The OCaml code emitted by Disk.print_ocaml is missing a String.escape
that was lost when the code was moved to use Bytes to make it
safe-string compliant. See commit

    7d96f3d9f9da2401884c6ebc1c2e984715719ca5

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>