### PR TITLE
XSI-19 locate VHD footer based on total file size

### DIFF
--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -1470,9 +1470,7 @@ module From_input = functor (I: S.INPUT) -> struct
     | None -> return ()
     | Some s ->
         let (&&&)  = Int64.logand in
-        let (~~~)  = Int64.lognot in
-        let sub1 n = Int64.(sub n 1L) in
-        let footer_offset = Int64.((sub1 s) &&& (~~~ 0b1_1111_1111L)) in
+        let footer_offset = Int64.(sub s 1L &&& lognot 0b1_1111_1111L) in
         (* offset is last 512-byte-aligned block in the file *)
         skip_to fd footer_offset) >>= fun () ->
     read fd buffer >>= fun () ->

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -1411,7 +1411,7 @@ module From_input = functor (I: S.INPUT) -> struct
 
   open Memory
 
-  let openstream fd =
+  let openstream size_opt fd =
     let buffer = alloc Footer.sizeof in
     read fd buffer >>= fun () ->
     Footer.unmarshal buffer >>|= fun footer ->
@@ -1466,6 +1466,15 @@ module From_input = functor (I: S.INPUT) -> struct
         sector 0 (fun () -> block (M.remove s blocks) andthen) in
     block phys_to_virt (fun () ->
     let buffer = alloc Footer.sizeof in
+    ( match size_opt with
+    | None -> return ()
+    | Some s ->
+        let (&&&)  = Int64.logand in
+        let (~~~)  = Int64.lognot in
+        let sub1 n = Int64.(sub n 1L) in
+        let footer_offset = Int64.((sub1 s) &&& (~~~ 0b1_1111_1111L)) in
+        (* offset is last 512-byte-aligned block in the file *)
+        skip_to fd footer_offset) >>= fun () ->
     read fd buffer >>= fun () ->
     Footer.unmarshal buffer >>|= fun footer ->
     Fragment.Footer footer >+> fun () ->

--- a/vhd_format/f.mli
+++ b/vhd_format/f.mli
@@ -375,7 +375,7 @@ module From_input : functor (I: S.INPUT) -> sig
     | End
   (** a lazy list *)
 
-  val openstream : fd -> Fragment.t ll t
+  val openstream : int64 option -> fd -> Fragment.t ll t
   (** produce a stream of Fragment.ts from a vhd stream, using constant space *)
 end
 

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -246,7 +246,9 @@ let stream_vhd filename =
 	end;*)
       tl () >>= fun x ->
       loop x in
-  openstream (Input.of_fd (Vhd_format_lwt.IO.to_file_descr fd)) >>= fun stream ->
+  Vhd_format_lwt.IO.get_file_size filename >>= fun size ->
+  openstream (Some size)
+    (Input.of_fd (Vhd_format_lwt.IO.to_file_descr fd)) >>= fun stream ->
   loop stream >>= fun () -> Vhd_format_lwt.IO.close fd
 
 let stream_test state =


### PR DESCRIPTION
The position of the footer in a VHD file depends on the total size of a
the file or stream that contains it. This commit adds code:

(1) to pass the total file size when it is known,
(2) to skip to the footer based on this information

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>
Signed-off-by: Christian Lindig <christian.lindig@citrix.com>