### PR TITLE
opam: use normalised OS string "macos" rather than "darwin"

### DIFF
--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -25,4 +25,4 @@ depends: [
 depexts: [
  [["alpine"]["linux-headers"]]
 ]
-available: [ (os = "linux" | os = "darwin") & ocaml-version >= "4.02.3" ]
+available: [ (os = "linux" | os = "macos") & ocaml-version >= "4.02.3" ]

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -22,4 +22,4 @@ depends: [
 depexts: [
  [["alpine"]["linux-headers"]]
 ]
-available: [ (os = "linux" | os = "darwin") & ocaml-version >= "4.02.3" ]
+available: [ (os = "linux" | os = "macos") & ocaml-version >= "4.02.3" ]


### PR DESCRIPTION
The CI is currently failing with
```
opam lint vhd-format-lwt.opam --warn=-21-32-48
/repo/vhd-format-lwt.opam: Errors.
             error 55: Non-normalised OS or arch string being tested: "darwin (use macos instead)"
```
See https://travis-ci.org/mirage/ocaml-vhd/jobs/415466518

Signed-off-by: David Scott <dave@recoil.org>