### PR TITLE
Expand lwt ppx into binds

### DIFF
--- a/disk/jbuild
+++ b/disk/jbuild
@@ -3,5 +3,4 @@
   (libraries
    (cstruct
     lwt
-    lwt.unix))
-  (preprocess (pps (lwt_ppx)))))
+    lwt.unix))))

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -18,7 +18,6 @@ depends: [
   "mirage-types-lwt" {>= "3.0.0"}
   "ounit"
   "vhd-format"
-  "lwt_ppx"
   "io-page-unix" {test}
   "jbuilder" {build}
 ]

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -15,7 +15,6 @@ depends: [
   "io-page"
   "rresult"
   "uuidm"
-  "lwt_ppx"
   "jbuilder" {build}
   "ppx_cstruct" {build}
 ]

--- a/vhd_format_lwt_test/input.ml
+++ b/vhd_format_lwt_test/input.ml
@@ -47,7 +47,7 @@ let complete name offset op fd buffer =
   else return ()
 
 let read fd buf =
-  let%lwt () = complete "read" (Some fd.offset) Lwt_bytes.read fd.fd buf in
+  complete "read" (Some fd.offset) Lwt_bytes.read fd.fd buf >>= fun () ->
   fd.offset <- Int64.(add fd.offset (of_int (Cstruct.len buf)));
   Lwt.return_unit
 
@@ -59,7 +59,7 @@ let skip_to fd n =
     else
       let this = Int64.(to_int (min remaining (of_int (Cstruct.len buf)))) in
       let frag = Cstruct.sub buf 0 this in
-      let%lwt () = complete "skip" (Some fd.offset) Lwt_bytes.read fd.fd frag in
+      complete "skip" (Some fd.offset) Lwt_bytes.read fd.fd frag >>= fun () ->
       fd.offset <- Int64.(add fd.offset (of_int this));
-      loop Int64.(sub remaining (of_int this)) in  
+      loop Int64.(sub remaining (of_int this)) in
   loop Int64.(sub n fd.offset)

--- a/vhd_format_lwt_test/input.ml
+++ b/vhd_format_lwt_test/input.ml
@@ -18,8 +18,6 @@ let (>>=) = Lwt.(>>=)
 let return = Lwt.return
 let fail = Lwt.fail
 
-open Lwt
-
 type fd = {
   fd: Lwt_unix.file_descr;
   mutable offset: int64;

--- a/vhd_format_lwt_test/jbuild
+++ b/vhd_format_lwt_test/jbuild
@@ -9,7 +9,7 @@
       oUnit
       vhd-format
       vhd_format_lwt))
-   (preprocess (pps (lwt_ppx)))))
+   ))
 
 (alias
   ((name   runtest)

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -12,7 +12,6 @@
  * GNU Lesser General Public License for more details.
  *)
 open OUnit
-open Lwt
 
 open Vhd_format.Patterns
 module Impl = Vhd_format.F.From_file(Vhd_format_lwt.IO)
@@ -231,7 +230,7 @@ let stream_vhd filename =
   Vhd_format_lwt.IO.openfile filename false >>= fun fd ->
   let rec loop = function
     | End -> return ()
-    | Cons (hd, tl) ->
+    | Cons (_hd, tl) ->
 (*      begin match hd with
       | Fragment.Header x ->
         Printf.printf "Header\n%!"


### PR DESCRIPTION
This avoids depending on Lwt ppx, which sometimes brings in different source versions of Lwt on the same system.