### PR TITLE
Remove dependency on integers package

### DIFF
--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -12,7 +12,6 @@ build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "cstruct"
-  "integers"
   "lwt" {>= "3.2.0"}
   "mirage-block"
   "mirage-types-lwt" {>= "3.0.0"}

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -11,7 +11,6 @@ dev-repo: "git://github.com/mirage/ocaml-vhd"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "cstruct" {>= "1.9"}
-  "integers"
   "io-page"
   "rresult"
   "uuidm"

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -876,12 +876,16 @@ module BAT = struct
 
   let length t = t.max_table_entries
 
+  let int64_from_uint32 u32 =
+    let (&&&) = Int64.logand in
+    Int64.(of_int32 u32 &&& 0x0000_0000_ffff_ffffL)
+
   let fold f t initial =
     let rec loop acc i =
       if i = t.max_table_entries
       then acc
       else
-        let v = get t i |> Unsigned.UInt32.of_int32 |> Unsigned.UInt32.to_int64 in
+        let v = get t i |> int64_from_uint32 in
         if v = unused'
         then loop acc (i + 1)
         else loop (f i v acc) (i + 1) in

--- a/vhd_format/jbuild
+++ b/vhd_format/jbuild
@@ -4,7 +4,6 @@
   (flags (:standard -w -32-34-37))
   (libraries
    (cstruct
-    integers
     io-page
     rresult
     uuidm))


### PR DESCRIPTION
The integers package is used to implement a conversion from unsigned
32bit integer to signed 64bit integer. This commit implements this
conversion directly such that the integers package is no longer a
dependency.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>