### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -14,7 +14,7 @@ depends: [
   "ounit"
   "vhd-format"
   "io-page-unix" {with-test}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 available: os = "linux" | os = "macos"
 build: [

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -11,7 +11,7 @@ depends: [
   "io-page"
   "rresult"
   "uuidm"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ppx_cstruct" {build}
 ]
 available: os = "linux" | os = "macos"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.