### PR TITLE
Compatibility with cstruct 6.0.0, drop dependency on ounit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: c
+os: linux
+dist: xenial
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
 script: bash -ex .travis-docker.sh
 services:
   - docker
-sudo: false
 env:
  global:
-   - PACKAGE=vhd-format
+   - PACKAGE=vhd-format-lwt
    - PINS="vhd-format:. vhd-format-lwt:."
- matrix:
+ jobs:
    - DISTRO=debian-stable OCAML_VERSION=4.03
-   - DISTRO=ubuntu OCAML_VERSION=4.04
+   - DISTRO=debian-stable OCAML_VERSION=4.04
    - DISTRO=debian-stable OCAML_VERSION=4.05
    - DISTRO=alpine OCAML_VERSION=4.07
+   - DISTRO=debian-stable OCAML_VERSION=4.08
+   - DISTRO=debian-stable OCAML_VERSION=4.10
+   - DISTRO=debian-stable OCAML_VERSION=4.11
+   - DISTRO=debian-stable OCAML_VERSION=4.12

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -7,11 +7,11 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "cstruct"
+  "cstruct" {< "7.0.0"}
   "lwt" {>= "3.2.0"}
-  "mirage-block"
-  "mirage-types-lwt" {>= "3.0.0"}
-  "ounit"
+  "mirage-block" {< "2.0.0"}
+  "mirage-types-lwt" {>= "3.0.0" & < "3.7.0"}
+  "ounit" {with-test}
   "vhd-format"
   "io-page-unix" {with-test}
   "dune" {>= "1.0"}

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -15,6 +15,7 @@ depends: [
   "vhd-format"
   "io-page-unix" {with-test}
   "dune" {>= "1.0"}
+  "io-page" {with-test & >= 2.4.0}
 ]
 available: os = "linux" | os = "macos"
 build: [

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -15,7 +15,7 @@ depends: [
   "vhd-format"
   "io-page-unix" {with-test}
   "dune" {>= "1.0"}
-  "io-page" {with-test & >= 2.4.0}
+  "io-page" {with-test & >= "2.4.0"}
 ]
 available: os = "linux" | os = "macos"
 build: [

--- a/vhd_format_lwt/dune
+++ b/vhd_format_lwt/dune
@@ -1,6 +1,5 @@
 (library
  (name vhd_format_lwt)
  (public_name vhd-format-lwt)
- (libraries cstruct lwt lwt.unix mirage-block mirage-types-lwt oUnit
-   vhd-format)
+ (libraries cstruct lwt lwt.unix mirage-block mirage-types-lwt vhd-format)
  (c_names blkgetsize64_stubs lseek64_stubs odirect_stubs))

--- a/vhd_format_lwt/iO.ml
+++ b/vhd_format_lwt/iO.ml
@@ -31,7 +31,7 @@ let complete name offset op fd buffer =
   then Printf.fprintf stderr "%s offset=%s buffer = [%s](%d)\n%!"
     name (match offset with Some x -> Int64.to_string x | None -> "None")
     (if Cstruct.len buffer > 16
-     then (String.escaped (Cstruct.(to_string (sub buffer 0 13)))) ^ "..."
+     then (String.escaped (Cstruct.to_string (Cstruct.sub buffer 0 13))) ^ "..."
      else (String.escaped (Cstruct.to_string buffer)))
     (Cstruct.len buffer);
   if n = 0 && len <> 0

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -18,7 +18,7 @@ module Impl = Vhd_format.F.From_file(Vhd_format_lwt.IO)
 open Impl
 open Vhd_format.F
 open Vhd_format_lwt.IO
-open Vhd_format_lwt.Patterns_lwt
+open Patterns_lwt
 
 let cstruct_to_string c = String.escaped (Cstruct.to_string c)
 

--- a/vhd_format_lwt_test/patterns_lwt.ml
+++ b/vhd_format_lwt_test/patterns_lwt.ml
@@ -14,6 +14,8 @@
 open OUnit
 open Lwt
 
+module IO = Vhd_format_lwt.IO
+
 module Impl = Vhd_format.F.From_file(IO)
 module F = Vhd_format.F
 module Field = F.Vhd.Field

--- a/vhd_format_lwt_test/patterns_lwt.mli
+++ b/vhd_format_lwt_test/patterns_lwt.mli
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-val verify: IO.fd Vhd_format.F.Vhd.t -> (int64 * Cstruct.t) list -> unit Lwt.t
+val verify: Vhd_format_lwt.IO.fd Vhd_format.F.Vhd.t -> (int64 * Cstruct.t) list -> unit Lwt.t
 (** [verify vhd sectors] performs various checks on [vhd] to ensure it has
     exactly the content given by [sectors], an association list of sector
     number to 512-byte block. *)


### PR DESCRIPTION
This includes the minimal change to make it compatible with both older cstructs as well as 6.0.0.

Looking ahead this could be changed to `Cstruct.to_string ~off:0 ~len:13 buffer` and all the `.len` replaced with `.length`, but that makes it not compatible with older versions.

The patterns module is only used for testing, I've moved it to the tests library. This allows dropping ounit from the package when it's not being tested.

The dependency constraints for mirage have been pulled from opam-repository. They will be tackled at some point.

Travis testing has been changed so all versions of ocaml are tested, and the package has been changed to vhd-format-lwt to force running the tests. This tests the building of both opam packages without making the amount of jobs to explode.