### PR TITLE
Add support for OCaml 4.13

### DIFF
--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -11,6 +11,7 @@ depends: [
   "io-page"
   "rresult" {>= "0.2.0"}
   "uuidm"
+  "stdlib-shims"
   "dune" {>= "1.0"}
   "ppx_cstruct" {build & >= "3.0.0"}
 ]

--- a/vhd_format/dune
+++ b/vhd_format/dune
@@ -2,5 +2,5 @@
  (name vhd_format)
  (public_name vhd-format)
  (flags :standard -w -32-34-37)
- (libraries cstruct io-page rresult uuidm)
+ (libraries stdlib-shims cstruct io-page rresult uuidm)
  (preprocess (pps ppx_cstruct)))

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -1514,7 +1514,7 @@ module From_file = functor(F: S.FILE) -> struct
     let write_this_time = max adjusted_len 512L in
     let remaining_to_write = adjusted_len -- write_this_time in
 
-    let useful_bytes_to_write = min (Cstruct.len buffer) (to_int (write_this_time -- offset ++ sector_start)) in
+    let useful_bytes_to_write = Stdlib.min (Cstruct.len buffer) (to_int (write_this_time -- offset ++ sector_start)) in
     Cstruct.blit buffer 0 current (to_int (offset -- sector_start)) useful_bytes_to_write;
     really_write fd sector_start current >>= fun () ->
     if remaining_to_write <= 0L


### PR DESCRIPTION
OCaml 4.13 added `Int64.min` and this shadows `Stdlib.min`.
To fix this I've added an explicit dependency towards `stdlib-shims` for convenience and "cleaness", and because it is already in the dependency tree (via ppx_cstruct and ppxlib) there shouldn't be any problem using it explicitly.