### PR TITLE
Use caml/unixsupport.h instead of extern

### DIFF
--- a/vhd_format_lwt/blkgetsize64_stubs.c
+++ b/vhd_format_lwt/blkgetsize64_stubs.c
@@ -29,6 +29,7 @@
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
+#include <caml/unixsupport.h>
 
 #ifdef __linux__
 # include <linux/fs.h>
@@ -37,10 +38,6 @@
 # include <sys/ioctl.h>
 # include <sys/disk.h>
 #endif
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
-#define Nothing ((value) 0)
 
 #define NOT_IMPLEMENTED (-1)
 #define TRIED_AND_FAILED (1)

--- a/vhd_format_lwt/lseek64_stubs.c
+++ b/vhd_format_lwt/lseek64_stubs.c
@@ -30,14 +30,11 @@
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
+#include <caml/unixsupport.h>
 
 #ifdef __linux__
 # include <linux/fs.h>
 #endif
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
-#define Nothing ((value) 0)
 
 CAMLprim value stub_lseek64_data(value fd, value ofs) {
   CAMLparam2(fd, ofs);

--- a/vhd_format_lwt/odirect_stubs.c
+++ b/vhd_format_lwt/odirect_stubs.c
@@ -27,10 +27,7 @@
 #include <caml/fail.h>
 #include <caml/callback.h>
 #include <caml/bigarray.h>
-
-/* ocaml/ocaml/unixsupport.c */
-extern void uerror(char *cmdname, value cmdarg);
-#define Nothing ((value) 0)
+#include <caml/unixsupport.h>
 
 CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
   CAMLparam3(filename, rw, perm);


### PR DESCRIPTION
This is equivalent to https://github.com/mirage/mirage-block-unix/pull/115, as ocaml-vhd contains the same C code.

While performing impact testing for https://github.com/ocaml/ocaml/pull/10926, I found this presumably older code which declared `uerror` as an `extern`. `caml/unixsupport.h` declares this function, which means that the code carries on working if we rename `uerror` (which we're planning on doing in 5.0!).

This PR could be merged regardless of the upstream OCaml PR.