### PR TITLE
opam: resync cstruct constraints with upstream

### DIFF
--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
 tags: ["org:mirage" "org:xapi-project"]
-license: "LGPL-2.1only WITH OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "cstruct" {>= "1.9" & < "6.1.0"}
+  "cstruct" {>= "1.9" & < "6.0.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
   "uuidm"

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -2,13 +2,13 @@ opam-version: "2.0"
 maintainer: "dave@recoil.org"
 authors: ["Dave Scott" "Jon Ludlam"]
 tags: ["org:mirage" "org:xapi-project"]
-license: "LGPL-2.1only WITH OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "cstruct" {>= "1.9"}
+  "cstruct" {>= "1.9" & < "6.1.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
   "uuidm"

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -11,7 +11,7 @@ depends: [
   "cstruct" {>= "1.9" & < "6.0.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
-  "uuidm"
+  "uuidm" {>= "0.9.6"}
   "stdlib-shims"
   "dune" {>= "1.0"}
   "ppx_cstruct" {build & >= "3.0.0"}

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -350,7 +350,7 @@ module Footer = struct
     ?(creator_host_os = Host_OS.Other 0l)
     ~current_size ?original_size
     ~disk_type
-    ?(uid = Uuidm.create `V4) ?(saved_state = false) () =
+    ?(uid = Uuidm.v `V4) ?(saved_state = false) () =
   let original_size = match original_size with
     | None -> current_size
     | Some x -> x in
@@ -1672,7 +1672,7 @@ module From_file = functor(F: S.FILE) -> struct
       return t
 
     let create_dynamic ~filename ~size
-      ?(uuid = Uuidm.create `V4)
+      ?(uuid = Uuidm.v `V4)
       ?(saved_state=false)
       ?(features=[]) () =
 
@@ -1723,7 +1723,7 @@ module From_file = functor(F: S.FILE) -> struct
 
     let create_difference ~filename ~parent
       ?(relative_path = true)
-      ?(uuid=Uuidm.create `V4)
+      ?(uuid=Uuidm.v `V4)
       ?(saved_state=false)
       ?(features=[]) () =
 


### PR DESCRIPTION
Latest version of `cstruct` no longer has a `len` function. It's an easy upgrade but it might cause problems for users if they aren't ready to upgrade yet so I'll not combine it with the OCaml 5.0 fix release.

Also I notice the license SPDX string was slightly differently formatted, so I went with the opam-repository version.

Signed-off-by: David Scott <dave@recoil.org>