### PR TITLE
Update usages of io-page and cstruct for compatibility with latest releases

### DIFF
--- a/disk/disk.ml
+++ b/disk/disk.ml
@@ -53,8 +53,8 @@ let print_ocaml out t =
   Printf.fprintf out "  let t = ref Disk.empty in\n";
   Int64Map.iter
     (fun ofs cstr ->
-      let buf = Bytes.make (Cstruct.len cstr) '\000' in
-      Cstruct.blit_to_bytes cstr 0 buf 0 (Cstruct.len cstr);
+      let buf = Bytes.make (Cstruct.length cstr) '\000' in
+      Cstruct.blit_to_bytes cstr 0 buf 0 (Cstruct.length cstr);
       Printf.fprintf out "  t := Disk.write_string !t %LdL \"%s\";\n"
         ofs (buf |> Bytes.to_string |> String.escaped)
     ) t;

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -13,7 +13,6 @@ depends: [
   "mirage-block" {>= "2.0.1"}
   "ounit2" {with-test}
   "vhd-format"
-  "io-page-unix" {with-test}
   "dune" {>= "1.0"}
   "io-page" {with-test & >= "2.4.0"}
 ]

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "cstruct"
+  "cstruct" {>= "6.0.0"}
   "lwt" {>= "3.2.0"}
   "mirage-block" {>= "2.0.1"}
   "ounit2" {with-test}

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "cstruct" {>= "1.9" & < "6.0.0"}
+  "cstruct" {> "6.0.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
   "uuidm" {>= "0.9.6"}

--- a/vhd_format/element.ml
+++ b/vhd_format/element.ml
@@ -27,9 +27,9 @@ let to_string = function
     Printf.sprintf "%Ld sectors copied starting at offset %Ld" len offset
   | `Sectors x ->
     let text = String.escaped (Cstruct.to_string (Cstruct.sub x 0 16)) in
-    if Cstruct.len x = sector_size
+    if Cstruct.length x = sector_size
     then Printf.sprintf "1 sector \"%s...\"" text
-    else Printf.sprintf "%d sectors \"%s...\"" (Cstruct.len x / sector_size) text
+    else Printf.sprintf "%d sectors \"%s...\"" (Cstruct.length x / sector_size) text
   | `Empty 1L ->
     "1 empty sector"
   | `Empty x ->
@@ -37,6 +37,6 @@ let to_string = function
 
 let len = function
   | `Copy(_, _, len) -> len
-  | `Sectors x -> Int64.of_int (Cstruct.len x / sector_size)
+  | `Sectors x -> Int64.of_int (Cstruct.length x / sector_size)
   | `Empty x -> x
 

--- a/vhd_format_lwt/blkgetsize64_stubs.c
+++ b/vhd_format_lwt/blkgetsize64_stubs.c
@@ -54,7 +54,7 @@ CAMLprim value stub_blkgetsize64(value filename){
   int rc = NOT_IMPLEMENTED;
   const char *filename_c = strdup(String_val(filename));
 
-  enter_blocking_section();
+  caml_enter_blocking_section();
   fd = open(filename_c, O_RDONLY, 0);
   if (fd >= 0) {
 #if defined(BLKGETSIZE64)
@@ -70,7 +70,7 @@ CAMLprim value stub_blkgetsize64(value filename){
 #endif
     close(fd);
   }
-  leave_blocking_section();
+  caml_leave_blocking_section();
   free((void*)filename_c);
 
   if (fd == -1) uerror("open", filename);

--- a/vhd_format_lwt/block.ml
+++ b/vhd_format_lwt/block.ml
@@ -57,8 +57,8 @@ let get_info t = return t.info
 
 let to_sectors bufs =
   let rec loop acc remaining =
-    if Cstruct.len remaining = 0 then List.rev acc else
-    let available = min 512 (Cstruct.len remaining) in
+    if Cstruct.length remaining = 0 then List.rev acc else
+    let available = min 512 (Cstruct.length remaining) in
     loop (Cstruct.sub remaining 0 available :: acc) (Cstruct.shift remaining available) in
   List.concat (List.map (loop []) bufs)
 
@@ -70,7 +70,7 @@ let forall_sectors f offset bufs =
 
 let zero =
   let buf = Cstruct.create 512 in
-  for i = 0 to Cstruct.len buf - 1 do
+  for i = 0 to Cstruct.length buf - 1 do
     Cstruct.set_uint8 buf i 0
   done;
   buf

--- a/vhd_format_lwt/iO.ml
+++ b/vhd_format_lwt/iO.ml
@@ -30,10 +30,10 @@ let complete name offset op fd buffer =
   if !debug_io
   then Printf.fprintf stderr "%s offset=%s buffer = [%s](%d)\n%!"
     name (match offset with Some x -> Int64.to_string x | None -> "None")
-    (if Cstruct.len buffer > 16
+    (if Cstruct.length buffer > 16
      then (String.escaped (Cstruct.to_string (Cstruct.sub buffer 0 13))) ^ "..."
      else (String.escaped (Cstruct.to_string buffer)))
-    (Cstruct.len buffer);
+    (Cstruct.length buffer);
   if n = 0 && len <> 0
   then fail End_of_file
   else return ()
@@ -82,7 +82,7 @@ module Fd = struct
     (* All reads and writes should be sector-aligned *)
     assert_sector_aligned offset;
     assert_sector_aligned (Int64.of_int buf.Cstruct.off);
-    assert_sector_aligned (Int64.of_int (Cstruct.len buf));
+    assert_sector_aligned (Int64.of_int (Cstruct.length buf));
 
     Lwt_mutex.with_lock lock
       (fun () ->
@@ -91,14 +91,14 @@ module Fd = struct
           complete "read" (Some offset) Lwt_bytes.read fd buf
         ) (function
         | Unix.Unix_error(Unix.EINVAL, "read", "") as e ->
-          Printf.fprintf stderr "really_read offset = %Ld len = %d: EINVAL (alignment?)\n%!" offset (Cstruct.len buf);
+          Printf.fprintf stderr "really_read offset = %Ld len = %d: EINVAL (alignment?)\n%!" offset (Cstruct.length buf);
           fail e
         | End_of_file as e ->
-          Printf.fprintf stderr "really_read offset = %Ld len = %d: End_of_file\n%!" offset (Cstruct.len buf);
+          Printf.fprintf stderr "really_read offset = %Ld len = %d: End_of_file\n%!" offset (Cstruct.length buf);
           fail e
         | e ->
           Printf.fprintf stderr "really_read offset = %Ld len = %d: %s\n%!"
-            offset (Cstruct.len buf) (Printexc.to_string e);
+            offset (Cstruct.length buf) (Printexc.to_string e);
           fail e
         )
       )
@@ -107,7 +107,7 @@ module Fd = struct
     (* All reads and writes should be sector-aligned *)
     assert_sector_aligned offset;
     assert_sector_aligned (Int64.of_int buf.Cstruct.off);
-    assert_sector_aligned (Int64.of_int (Cstruct.len buf));
+    assert_sector_aligned (Int64.of_int (Cstruct.length buf));
 
     Lwt_mutex.with_lock lock
       (fun () ->
@@ -116,14 +116,14 @@ module Fd = struct
           complete "write" (Some offset) Lwt_bytes.write fd buf
         ) (function
         | Unix.Unix_error(Unix.EINVAL, "write", "") as e ->
-          Printf.fprintf stderr "really_write offset = %Ld len = %d: EINVAL (alignment?)\n%!" offset (Cstruct.len buf);
+          Printf.fprintf stderr "really_write offset = %Ld len = %d: EINVAL (alignment?)\n%!" offset (Cstruct.length buf);
           fail e
         | End_of_file as e ->
-          Printf.fprintf stderr "really_write offset = %Ld len = %d: End_of_file\n%!" offset (Cstruct.len buf);
+          Printf.fprintf stderr "really_write offset = %Ld len = %d: End_of_file\n%!" offset (Cstruct.length buf);
           fail e
         | e ->
           Printf.fprintf stderr "really_write offset = %Ld len = %d: %s\n%!"
-            offset (Cstruct.len buf) (Printexc.to_string e);
+            offset (Cstruct.length buf) (Printexc.to_string e);
           fail e
         )
       )

--- a/vhd_format_lwt/odirect_stubs.c
+++ b/vhd_format_lwt/odirect_stubs.c
@@ -36,7 +36,7 @@ CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
 
   const char *filename_c = strdup(String_val(filename));
 
-  enter_blocking_section();
+  caml_enter_blocking_section();
   int flags = 0;
 #if defined(O_DIRECT)
   flags |= O_DIRECT;
@@ -47,7 +47,7 @@ CAMLprim value stub_openfile_direct(value filename, value rw, value perm){
     flags |= O_RDONLY;
   }
   fd = open(filename_c, flags, Int_val(perm));
-  leave_blocking_section();
+  caml_leave_blocking_section();
 
   free((void*)filename_c);
 

--- a/vhd_format_lwt_test/dune
+++ b/vhd_format_lwt_test/dune
@@ -1,6 +1,6 @@
 (executable
  (name parse_test)
- (libraries cstruct disk io-page.unix lwt lwt.unix ounit2 vhd-format
+ (libraries cstruct disk io-page lwt lwt.unix ounit2 vhd-format
    vhd_format_lwt))
 
 (alias

--- a/vhd_format_lwt_test/input.ml
+++ b/vhd_format_lwt_test/input.ml
@@ -29,7 +29,7 @@ let of_fd fd =
 
 let complete name offset op fd buffer =
   if false
-  then Printf.fprintf stderr "%s offset=%s length=%d\n%!" name (match offset with Some x -> Int64.to_string x | None -> "None") (Cstruct.len buffer);
+  then Printf.fprintf stderr "%s offset=%s length=%d\n%!" name (match offset with Some x -> Int64.to_string x | None -> "None") (Cstruct.length buffer);
   let open Lwt in
   let ofs = buffer.Cstruct.off in
   let len = buffer.Cstruct.len in
@@ -48,7 +48,7 @@ let complete name offset op fd buffer =
 
 let read fd buf =
   complete "read" (Some fd.offset) Lwt_bytes.read fd.fd buf >>= fun () ->
-  fd.offset <- Int64.(add fd.offset (of_int (Cstruct.len buf)));
+  fd.offset <- Int64.(add fd.offset (of_int (Cstruct.length buf)));
   Lwt.return_unit
 
 let skip_to fd n =
@@ -57,7 +57,7 @@ let skip_to fd n =
     if remaining = 0L
     then Lwt.return_unit
     else
-      let this = Int64.(to_int (min remaining (of_int (Cstruct.len buf)))) in
+      let this = Int64.(to_int (min remaining (of_int (Cstruct.length buf)))) in
       let frag = Cstruct.sub buf 0 this in
       complete "skip" (Some fd.offset) Lwt_bytes.read fd.fd frag >>= fun () ->
       fd.offset <- Int64.(add fd.offset (of_int this));

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -241,7 +241,7 @@ let stream_vhd filename =
       | Fragment.Batmap x ->
         Printf.printf "batmap\n%!"
       | Fragment.Block (offset, buffer) ->
-        Printf.printf "Block %Ld (len %d)\n%!" offset (Cstruct.len buffer)
+        Printf.printf "Block %Ld (len %d)\n%!" offset (Cstruct.length buffer)
 	end;*)
       tl () >>= fun x ->
       loop x in

--- a/vhd_format_lwt_test/patterns_lwt.ml
+++ b/vhd_format_lwt_test/patterns_lwt.ml
@@ -116,7 +116,7 @@ let check_raw_stream_contents t expected =
       return (Int64.(add offset len))
     | `Sectors data ->
       let rec loop offset remaining =
-        if Cstruct.len remaining = 0
+        if Cstruct.length remaining = 0
         then return offset
         else
           (* the sector [offset] should be in the contents list *)
@@ -149,12 +149,12 @@ let verify t contents =
         | `Empty y -> return (Int64.(add offset (mul y 512L)))
         | `Sectors data ->
           IO.really_write fd offset data >>= fun () ->
-          return (Int64.(add offset (of_int (Cstruct.len data))))
+          return (Int64.(add offset (of_int (Cstruct.length data))))
         | `Copy(fd', offset', len') ->
           let buf = Memory.alloc (Int64.to_int len' * 512) in
           IO.really_read fd' (Int64.mul offset' 512L) buf >>= fun () ->
           IO.really_write fd offset buf >>= fun () ->
-          return (Int64.(add offset (of_int (Cstruct.len buf))))
+          return (Int64.(add offset (of_int (Cstruct.length buf))))
       ) 0L stream.elements in
 
     (* Stream the contents as a fresh vhd *)


### PR DESCRIPTION
Now io-page at least 2.4.0 and cstruct 6.0.0 are required.