### PR TITLE
Apply changes done to the fork in xapi

### DIFF
--- a/cli/dune
+++ b/cli/dune
@@ -2,4 +2,4 @@
  (name disk_to_ocaml)
  (public_name disk_to_ocaml)
  (package vhd-format-lwt)
- (libraries disk lwt))
+ (libraries disk lwt lwt.unix))

--- a/disk/dune
+++ b/disk/dune
@@ -1,3 +1,4 @@
 (library
  (name disk)
+ (package vhd-format-lwt)
  (libraries cstruct lwt lwt.unix))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 2.0)
 (name vhd-format)
+(implicit_transitive_deps false)

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.0)
+(lang dune 2.8)
 (name vhd-format)
 (implicit_transitive_deps false)

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 2.0)
 (name vhd-format)

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -8,12 +8,14 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test & >= "1.0.0"}
   "bigarray-compat" {>= "1.1.0"}
   "cstruct" {>= "6.0.0"}
   "cstruct-lwt"
+  "fmt" {with-test}
   "lwt" {>= "3.2.0"}
   "mirage-block" {>= "3.0.0"}
-  "ounit2" {with-test}
   "rresult" {>= "0.7.0"}
   "vhd-format" {= version}
   "dune" {>= "2.0"}

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.10"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test & >= "1.0.0"}
   "bigarray-compat" {>= "1.1.0"}

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-block" {>= "3.0.0"}
   "rresult" {>= "0.7.0"}
   "vhd-format" {= version}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8"}
   "io-page" {with-test & >= "2.4.0"}
 ]
 available: os = "linux" | os = "macos"

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -8,12 +8,15 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
+  "bigarray-compat" {>= "1.1.0"}
   "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
   "lwt" {>= "3.2.0"}
-  "mirage-block" {>= "2.0.1"}
+  "mirage-block" {>= "3.0.0"}
   "ounit2" {with-test}
-  "vhd-format"
-  "dune" {>= "1.0"}
+  "rresult" {>= "0.7.0"}
+  "vhd-format" {= version}
+  "dune" {>= "2.0"}
   "io-page" {with-test & >= "2.4.0"}
 ]
 available: os = "linux" | os = "macos"

--- a/vhd-format-lwt.opam
+++ b/vhd-format-lwt.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.05"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test & >= "1.0.0"}
   "bigarray-compat" {>= "1.1.0"}

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -8,12 +8,13 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "cstruct" {> "6.0.0"}
+  "bigarray-compat" {>= "1.1.0"}
+  "cstruct" {>= "6.0.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
   "uuidm" {>= "0.9.6"}
   "stdlib-shims"
-  "dune" {>= "1.0"}
+  "dune" {>= "2.0"}
   "ppx_cstruct" {build & >= "3.0.0"}
 ]
 available: os = "linux" | os = "macos"

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.10.0"}
   "bigarray-compat" {>= "1.1.0"}
   "cstruct" {>= "6.0.0"}
   "io-page"

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -12,7 +12,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
-  "uuidm" {>= "0.9.6"}
+  "uuidm" {>= "0.9.9"}
   "stdlib-shims"
   "dune" {>= "2.0"}
   "ppx_cstruct" {build & >= "3.0.0"}

--- a/vhd-format.opam
+++ b/vhd-format.opam
@@ -14,7 +14,7 @@ depends: [
   "rresult" {>= "0.3.0"}
   "uuidm" {>= "0.9.9"}
   "stdlib-shims"
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8"}
   "ppx_cstruct" {build & >= "3.0.0"}
 ]
 available: os = "linux" | os = "macos"

--- a/vhd_format/dune
+++ b/vhd_format/dune
@@ -2,5 +2,5 @@
  (name vhd_format)
  (public_name vhd-format)
  (flags :standard -w -32-34-37)
- (libraries stdlib-shims cstruct io-page rresult uuidm)
+ (libraries stdlib-shims (re_export bigarray-compat) cstruct io-page rresult uuidm)
  (preprocess (pps ppx_cstruct)))

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -29,11 +29,7 @@ exception Cstruct_differ
 let cstruct_equal a b =
   let check_contents a b =
     try
-      for i = 0 to Cstruct.length a - 1 do
-        let a' = Cstruct.get_char a i in
-        let b' = Cstruct.get_char b i in
-        if a' <> b' then raise Cstruct_differ
-      done;
+      if Cstruct.compare a b <> 0 then raise Cstruct_differ ;
       true
     with _ -> false in
   (Cstruct.length a = (Cstruct.length b)) && (check_contents a b)

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -251,7 +251,7 @@ module UTF16 = struct
         end
       else
         failwith "Bad unicode character!" in
-    String.concat "" (List.map (fun c -> Printf.sprintf "%c" c) (List.flatten (List.map utf8_chars_of_int (Array.to_list s))))
+    String.concat "" (List.map (fun c -> Printf.sprintf "%c" c) (List.concat_map utf8_chars_of_int (Array.to_list s)))
 
   let to_utf8 x =
     try
@@ -1186,7 +1186,7 @@ module Vhd = struct
           let start = l.platform_data_offset in
           let length = Int64.of_int32 l.platform_data_space in
           tomarkers name start length) locators in
-        (List.flatten locations) @ blocks
+        (List.concat locations) @ blocks
       end else blocks in
     let bat_start = t.header.Header.table_offset in
     let bat_size = Int64.of_int t.header.Header.max_table_entries in

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -1237,11 +1237,6 @@ module Vhd = struct
   module Field = struct
     (** Dynamically-typed field-level access *)
 
-    type 'a f = {
-      name: string;
-      get: 'a t -> string;
-    }
-
     let _features = "features"
     let _data_offset = "data-offset"
     let _timestamp = "time-stamp"
@@ -1342,8 +1337,6 @@ module Vhd = struct
       else if key = _batmap_checksum
       then opt (fun (t, _) -> Int32.to_string t.Batmap_header.checksum) t.batmap
       else None
-    type 'a t = 'a f
-
    end
 end
 

--- a/vhd_format/f.ml
+++ b/vhd_format/f.ml
@@ -354,12 +354,9 @@ module Footer = struct
     ?(creator_application = default_creator_application)
     ?(creator_version = default_creator_version)
     ?(creator_host_os = Host_OS.Other 0l)
-    ~current_size ?original_size
+    ~current_size ?(original_size = current_size)
     ~disk_type
     ?(uid = Uuidm.v `V4) ?(saved_state = false) () =
-  let original_size = match original_size with
-    | None -> current_size
-    | Some x -> x in
   let geometry = Geometry.of_sectors Int64.(current_size lsr sector_shift) in
   let checksum = 0l in
   { features; data_offset; time_stamp; creator_application;

--- a/vhd_format/f.mli
+++ b/vhd_format/f.mli
@@ -507,5 +507,7 @@ module From_file : functor (F : S.FILE) -> sig
     val vhd : fd Raw.t -> fd stream t
   end
 
+  module Hybrid_raw_input : sig
+    val vhd : fd Raw.t -> (blocks:int -> block_size:Int64.t -> int list F.t) -> fd stream t
+  end
 end
-

--- a/vhd_format/patterns.ml
+++ b/vhd_format/patterns.ml
@@ -79,7 +79,7 @@ let string_of_operation = function
   | Write (p, _) -> Printf.sprintf "Write:%s:%s" (string_of_choice p.block) (string_of_choice p.sector)
 
 let descr_of_program p =
-  let lines = List.concat (List.map descr_of_operation p) in
+  let lines = List.concat_map descr_of_operation p in
   List.rev (fst (List.fold_left (fun (sofar, next) line ->
     Printf.sprintf "%d %s" (next * 10) line :: sofar, next + 1
   ) ([], 1) lines))

--- a/vhd_format_lwt/block.ml
+++ b/vhd_format_lwt/block.ml
@@ -55,7 +55,7 @@ let to_sectors bufs =
     if Cstruct.length remaining = 0 then List.rev acc else
     let available = min 512 (Cstruct.length remaining) in
     loop (Cstruct.sub remaining 0 available :: acc) (Cstruct.shift remaining available) in
-  List.concat (List.map (loop []) bufs)
+  List.concat_map (loop []) bufs
 
 let forall_sectors f offset bufs =
   let rec one offset = function

--- a/vhd_format_lwt/block.ml
+++ b/vhd_format_lwt/block.ml
@@ -26,11 +26,7 @@ let pp_write_error = Mirage_block.pp_write_error
 
 type info = Mirage_block.info
 
-type t = {
-  mutable vhd: IO.fd Vhd_format.F.Vhd.t option;
-  info: info;
-  id: string;
-}
+type t = {mutable vhd: IO.fd Vhd_format.F.Vhd.t option; info: info}
 
 let connect path =
   Lwt_unix.LargeFile.stat path >>= fun _ ->
@@ -43,8 +39,7 @@ let connect path =
   let sector_size = 512 in
   let size_sectors = Int64.div vhd.Vhd.footer.Footer.current_size 512L in
   let info = Mirage_block.{ read_write; sector_size; size_sectors } in
-  let id = path in
-  return ({ vhd = Some vhd; info; id })
+  return ({ vhd = Some vhd; info })
 
 let disconnect t = match t.vhd with
   | None -> return ()

--- a/vhd_format_lwt/dune
+++ b/vhd_format_lwt/dune
@@ -1,7 +1,7 @@
 (library
  (name vhd_format_lwt)
  (public_name vhd-format-lwt)
- (libraries cstruct lwt lwt.unix mirage-block vhd-format)
+ (libraries bigarray-compat cstruct-lwt cstruct lwt lwt.unix mirage-block vhd-format rresult)
  (foreign_stubs
    (language c)
    (names blkgetsize64_stubs lseek64_stubs odirect_stubs)))

--- a/vhd_format_lwt/dune
+++ b/vhd_format_lwt/dune
@@ -2,4 +2,6 @@
  (name vhd_format_lwt)
  (public_name vhd-format-lwt)
  (libraries cstruct lwt lwt.unix mirage-block vhd-format)
- (c_names blkgetsize64_stubs lseek64_stubs odirect_stubs))
+ (foreign_stubs
+   (language c)
+   (names blkgetsize64_stubs lseek64_stubs odirect_stubs)))

--- a/vhd_format_lwt/iO.ml
+++ b/vhd_format_lwt/iO.ml
@@ -41,17 +41,13 @@ let complete name offset op fd buffer =
 module Fd = struct
   open Lwt
 
-  type fd = {
-    fd: Lwt_unix.file_descr;
-    filename: string;
-    lock: Lwt_mutex.t;
-  }
+  type fd = { fd: Lwt_unix.file_descr; lock: Lwt_mutex.t; }
 
   let openfile filename rw =
     let unix_fd = File.openfile filename rw 0o644 in
     let fd = Lwt_unix.of_unix_file_descr unix_fd in
     let lock = Lwt_mutex.create () in
-    return { fd; filename; lock }
+    return { fd; lock }
 
   let fsync { fd = fd; _ } =
     let fd' = Lwt_unix.unix_file_descr fd in

--- a/vhd_format_lwt_test/dune
+++ b/vhd_format_lwt_test/dune
@@ -1,5 +1,5 @@
 (test
  (name parse_test)
  (package vhd-format-lwt)
- (libraries cstruct disk io-page lwt lwt.unix ounit2 vhd-format
+ (libraries alcotest alcotest-lwt cstruct disk io-page fmt lwt lwt.unix vhd-format
    vhd_format_lwt))

--- a/vhd_format_lwt_test/dune
+++ b/vhd_format_lwt_test/dune
@@ -1,12 +1,5 @@
-(executable
+(test
  (name parse_test)
+ (package vhd-format-lwt)
  (libraries cstruct disk io-page lwt lwt.unix ounit2 vhd-format
    vhd_format_lwt))
-
-(alias
- (name runtest)
- (package vhd-format-lwt)
- (deps
-  (:< parse_test.exe))
- (action
-  (run %{<})))

--- a/vhd_format_lwt_test/lib.mli
+++ b/vhd_format_lwt_test/lib.mli
@@ -16,3 +16,11 @@ val verify: Vhd_format_lwt.IO.fd Vhd_format.F.Vhd.t -> (int64 * Cstruct.t) list 
 (** [verify vhd sectors] performs various checks on [vhd] to ensure it has
     exactly the content given by [sectors], an association list of sector
     number to 512-byte block. *)
+
+val header : Vhd_format.F.Header.t Alcotest.testable
+
+val footer : Vhd_format.F.Footer.t Alcotest.testable
+
+val bat : Vhd_format.F.BAT.t Alcotest.testable
+
+val cstruct : Cstruct.t Alcotest.testable

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -165,11 +165,11 @@ let initial = {
 
 let sectors = Hashtbl.create 16
 let sector_lookup message =
-  if Hashtbl.mem sectors message
-  then Hashtbl.find sectors message
-  else
+  match Hashtbl.find_opt sectors message with
+  | Some x -> x
+  | None ->
     let data = fill_sector_with message in
-    Hashtbl.replace sectors message data;
+    Hashtbl.replace sectors message data ;
     data
 
 let execute state = function

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -275,12 +275,6 @@ let all_program_tests = List.map (fun p ->
 ) programs
 
 let _ =
-  let verbose = ref false in
-  Arg.parse [
-    "-verbose", Arg.Unit (fun _ -> verbose := true), "Run in verbose mode";
-  ] (fun x -> Printf.fprintf stderr "Ignoring argument: %s" x)
-    "Test vhd parser";
-
   let check_empty_disk size =
     Printf.sprintf "check_empty_disk_%Ld" size
     >:: (fun () -> Lwt_main.run (check_empty_disk size)) in
@@ -311,5 +305,4 @@ let _ =
        @ (List.map check_resize sizes)
        @ (List.map check_empty_snapshot sizes)
        @ all_program_tests in
-  run_test_tt ~verbose:!verbose suite
-
+  run_test_tt_main suite

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -39,7 +39,11 @@ let make_new_filename =
   fun () ->
     let this = !counter in
     incr counter;
-    disk_name_stem ^ (string_of_int this) ^ disk_suffix
+    let name = disk_name_stem ^ string_of_int this ^ disk_suffix in
+    at_exit (fun () ->
+        try Unix.unlink name with Unix.Unix_error (_, _, _) -> ()
+    ) ;
+    name
 
 let fill_sector_with pattern =
   let b = Io_page.(to_cstruct (get 1)) in

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -11,20 +11,15 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open OUnit
-
 open Vhd_format.Patterns
 module Impl = Vhd_format.F.From_file(Vhd_format_lwt.IO)
 open Impl
 open Vhd_format.F
 open Vhd_format_lwt.IO
-open Patterns_lwt
 
-let cstruct_to_string c = String.escaped (Cstruct.to_string c)
-
-let create () =
+let create _ () =
   let _ = Create_vhd.disk in
-  ()
+  Lwt.return ()
 
 let tmp_file_dir = Filename.get_temp_dir_name ()
 let disk_name_stem = tmp_file_dir ^ "/parse_test."
@@ -54,11 +49,10 @@ let check_empty_disk size =
   let filename = make_new_filename () in
   Vhd_IO.create_dynamic ~filename ~size () >>= fun vhd ->
   Vhd_IO.openchain filename false >>= fun vhd' ->
-  assert_equal ~printer:Header.to_string ~cmp:Header.equal vhd.Vhd.header vhd'.Vhd.header;
-  assert_equal ~printer:Footer.to_string vhd.Vhd.footer vhd'.Vhd.footer;
-  assert_equal ~printer:BAT.to_string ~cmp:BAT.equal vhd.Vhd.bat vhd'.Vhd.bat;
-  Vhd_IO.close vhd' >>= fun () ->
-  Vhd_IO.close vhd
+  Alcotest.check Lib.header "Header matches" vhd.Vhd.header vhd'.Vhd.header ;
+  Alcotest.check Lib.footer "Footer matches" vhd.Vhd.footer vhd'.Vhd.footer ;
+  Alcotest.check Lib.bat "BAT matches" vhd.Vhd.bat vhd'.Vhd.bat ;
+  Vhd_IO.close vhd' >>= fun () -> Vhd_IO.close vhd
 
 (* Create a disk, resize it, check headers *)
 let check_resize size =
@@ -68,7 +62,7 @@ let check_resize size =
   let vhd = Vhd.resize vhd newsize in
   Vhd_IO.close vhd >>= fun () ->
   Vhd_IO.openchain filename false >>= fun vhd' ->
-  assert_equal ~printer:Int64.to_string newsize vhd.Vhd.footer.Footer.current_size;
+  Alcotest.(check int64) "Footer size matches" newsize vhd.Vhd.footer.Footer.current_size ;
   Vhd_IO.close vhd'
 
 (* Create a snapshot, check headers *)
@@ -78,9 +72,9 @@ let check_empty_snapshot size =
   let filename = make_new_filename () in
   Vhd_IO.create_difference ~filename ~parent:vhd () >>= fun vhd' ->
   Vhd_IO.openchain filename false >>= fun vhd'' ->
-  assert_equal ~printer:Header.to_string ~cmp:Header.equal vhd'.Vhd.header vhd''.Vhd.header;
-  assert_equal ~printer:Footer.to_string vhd'.Vhd.footer vhd''.Vhd.footer;
-  assert_equal ~printer:BAT.to_string ~cmp:BAT.equal vhd'.Vhd.bat vhd''.Vhd.bat;
+  Alcotest.check Lib.header "Header matches" vhd'.Vhd.header vhd''.Vhd.header ;
+  Alcotest.check Lib.footer "Footer matches" vhd'.Vhd.footer vhd''.Vhd.footer ;
+  Alcotest.check Lib.bat "BAT matches" vhd'.Vhd.bat vhd''.Vhd.bat ;
   Vhd_IO.close vhd'' >>= fun () ->
   Vhd_IO.close vhd' >>= fun () ->
   Vhd_IO.close vhd
@@ -103,10 +97,9 @@ let check_reparent () =
   let l = make_new_filename () in
   Vhd_IO.openchain p1 false >>= fun vhd ->
   Vhd_IO.create_difference ~filename:l ~parent:vhd () >>= fun vhd' ->
-  (* Verify block 0 has '1' *)
   let sector = fill_sector_with "0" in
   Vhd_IO.read_sector vhd' 0L sector >>= fun _ ->
-  assert_equal ~printer:cstruct_to_string ~cmp:cstruct_equal all_ones sector;
+  Alcotest.check Lib.cstruct "Block 0 has '1'" all_ones sector ;
   Vhd_IO.close vhd' >>= fun () ->
   Vhd_IO.close vhd >>= fun () ->
   (* Flip the parent locator *)
@@ -115,10 +108,9 @@ let check_reparent () =
   let vhd' = { vhd' with Vhd.header } in
   Vhd_IO.close vhd' >>= fun () ->
   Vhd_IO.openchain l false >>= fun vhd ->
-  (* Verify block 0 has '2' *)
   let sector = fill_sector_with "0" in
   Vhd_IO.read_sector vhd 0L sector >>= fun _ ->
-  assert_equal ~printer:cstruct_to_string ~cmp:cstruct_equal all_twos sector;
+  Alcotest.check Lib.cstruct "Block 0 has '2'" all_twos sector ;
   Vhd_IO.close vhd
 
 (* Check ../ works in parent locator *)
@@ -217,9 +209,8 @@ let execute state = function
         return state
     end
 
-let verify state = match state.child with
-  | None -> return ()
-  | Some t -> verify t state.contents
+let verify state =
+  match state.child with None -> return () | Some t -> Lib.verify t state.contents
 
 module In = From_input(Input)
 open In
@@ -268,22 +259,28 @@ let run program =
   >>= fun () ->
   cleanup final_state
 
-let all_program_tests = List.map (fun p ->
-  (string_of_program p) >:: (fun () -> Lwt_main.run (run p))
-) programs
+let test = Alcotest_lwt.test_case
 
-let _ =
+let all_program_tests = List.map
+  (fun p -> test (string_of_program p) `Slow (fun _ () -> run p))
+  programs
+
+let () =
   let check_empty_disk size =
-    Printf.sprintf "check_empty_disk_%Ld" size
-    >:: (fun () -> Lwt_main.run (check_empty_disk size)) in
+    test (Printf.sprintf "size %Ld" size) `Quick (fun _ () ->
+        check_empty_disk size
+    )
+  in
 
   let check_resize size =
-    Printf.sprintf "check_resize_%Ld" size
-    >:: (fun () -> Lwt_main.run (check_resize size)) in
+    test (Printf.sprintf "size %Ld" size) `Quick (fun _ () -> check_resize size)
+  in
 
   let check_empty_snapshot size =
-    Printf.sprintf "check_empty_snapshot_%Ld" size
-    >:: (fun () -> Lwt_main.run (check_empty_snapshot size)) in
+    test (Printf.sprintf "size %Ld" size) `Quick (fun _ () ->
+        check_empty_snapshot size
+    )
+  in
 
   (* Switch to the 'nobody' user so we can test file permissions *)
   let nobody = Unix.getpwnam "nobody" in
@@ -291,16 +288,26 @@ let _ =
     try
       Unix.setuid nobody.Unix.pw_uid;
     with e ->
-      Printf.fprintf stderr "WARNING: failed to setuid to a non-priviledged user, access control tests will pass spuriously (%s)\n%!" (Printexc.to_string e)
+      Printf.fprintf stderr
+        "WARNING: failed to setuid to a non-priviledged user, access control \
+         tests will pass spuriously (%s)\n\
+         %!"
+        (Printexc.to_string e)
   end;
-  let suite = "vhd" >:::
+  let suite =
     [
-      "create" >:: create;
-      "check_parent_parent_dir" >:: (fun () -> Lwt_main.run (check_parent_parent_dir ()));
-      "check_readonly" >:: (fun () -> Lwt_main.run (check_readonly ()));
-      "check_reparent" >:: (fun () -> Lwt_main.run (check_reparent ()));
-     ] @ (List.map check_empty_disk sizes)
-       @ (List.map check_resize sizes)
-       @ (List.map check_empty_snapshot sizes)
-       @ all_program_tests in
-  run_test_tt_main suite
+      ( "Simple"
+      , [
+          test "create" `Quick create
+        ; test "parent_parent_dir" `Quick (fun _ -> check_parent_parent_dir)
+        ; test "readonly" `Quick (fun _ () -> check_readonly ())
+        ; test "reparent" `Quick (fun _ () -> check_reparent ())
+        ]
+      )
+    ; ("Empty disk", List.map check_empty_disk sizes)
+    ; ("Resize", List.map check_resize sizes)
+    ; ("Empty snapshots", List.map check_empty_snapshot sizes)
+    ; ("All program test", all_program_tests)
+    ]
+  in
+  Lwt_main.run @@ Alcotest_lwt.run "vhd_format_lwt" suite

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -26,10 +26,6 @@ let create () =
   let _ = Create_vhd.disk in
   ()
 
-let diff () =
-  let _ = Diff_vhd.disk in
-  ()
-
 let tmp_file_dir = Filename.get_temp_dir_name ()
 let disk_name_stem = tmp_file_dir ^ "/parse_test."
 let disk_suffix = ".vhd"
@@ -160,8 +156,6 @@ let absolute_sector_of vhd { block; sector } =
     | First -> 0
     | Last -> sectors_per_block - 1 in
     Some (Int64.(add(mul (of_int block) (of_int sectors_per_block)) (of_int relative_sector)))
-
-let cstruct_to_string c = String.escaped (Cstruct.to_string c)
 
 type state = {
   to_close: fd Vhd.t list;

--- a/vhd_format_lwt_test/parse_test.ml
+++ b/vhd_format_lwt_test/parse_test.ml
@@ -30,7 +30,7 @@ let diff () =
   let _ = Diff_vhd.disk in
   ()
 
-let tmp_file_dir = "/tmp"
+let tmp_file_dir = Filename.get_temp_dir_name ()
 let disk_name_stem = tmp_file_dir ^ "/parse_test."
 let disk_suffix = ".vhd"
 

--- a/vhd_format_lwt_test/patterns_lwt.ml
+++ b/vhd_format_lwt_test/patterns_lwt.ml
@@ -39,7 +39,11 @@ let make_new_filename =
   fun () ->
     let this = !counter in
     incr counter;
-    disk_name_stem ^ (string_of_int this) ^ disk_suffix
+    let name = disk_name_stem ^ string_of_int this ^ disk_suffix in
+    at_exit (fun () ->
+        try Unix.unlink name with Unix.Unix_error (_, _, _) -> ()
+    ) ;
+    name
 
 let _fill_sector_with pattern =
   let b = Memory.alloc 512 in

--- a/vhd_format_lwt_test/patterns_lwt.ml
+++ b/vhd_format_lwt_test/patterns_lwt.ml
@@ -31,7 +31,7 @@ module Memory = struct
       Cstruct.sub pages 0 bytes
 end
 
-let disk_name_stem = "/tmp/dynamic."
+let disk_name_stem = Filename.get_temp_dir_name () ^ "/dynamic."
 let disk_suffix = ".vhd"
 
 let make_new_filename =


### PR DESCRIPTION
These are most of the changes accumulated in xapi, I left some because they need a newer version of ocaml (Hashtbl.find_opt and List.concat_map), and the formatting ones because they're specific to xapi.
I need to spend some more time to see whether the existing changes changed the lower bound, maybe we want to drop support for older compilers, I'm not sure on the general stance for mirage repositories.

The history of the library inside xapi can be inspected here: https://github.com/xapi-project/xen-api/commits/master/ocaml/libs/vhd