### PR TITLE
Prepare v0.13.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,14 @@
+## v0.13.0 (2024-11-11)
+* Add explicit dependencies to the unix library (psafont, #79)
+* Include changes present in the in xapi. (#78)
+  - Add Hybrid_raw_input (robhoes)
+  - Limit the size of sectors when coalescing (Vincent-lau)
+  - Speed up unit tests, make them more reliable (etorok, psafont)
+  - Replace some existing patterns with functions in newer compiler versions,
+    requires OCaml 4.10 (last-genius, contificate)
+* Update usages of io-page and cstruct for compatibility with latest releases
+  (psafont #77)
+
 ## v0.12.3 (2022-06-19)
 * Lint opam file (@kit-ty-kate, #72)
 * Use ounit2 (@Alessandro-Barbieri, #73)

--- a/disk/dune
+++ b/disk/dune
@@ -1,4 +1,4 @@
 (library
  (name disk)
  (package vhd-format-lwt)
- (libraries cstruct lwt lwt.unix))
+ (libraries cstruct lwt lwt.unix unix))

--- a/vhd_format/dune
+++ b/vhd_format/dune
@@ -2,5 +2,5 @@
  (name vhd_format)
  (public_name vhd-format)
  (flags :standard -w -32-34-37)
- (libraries stdlib-shims (re_export bigarray-compat) cstruct io-page rresult uuidm)
+ (libraries stdlib-shims (re_export bigarray-compat) cstruct io-page rresult unix uuidm)
  (preprocess (pps ppx_cstruct)))

--- a/vhd_format_lwt/dune
+++ b/vhd_format_lwt/dune
@@ -1,7 +1,7 @@
 (library
  (name vhd_format_lwt)
  (public_name vhd-format-lwt)
- (libraries bigarray-compat cstruct-lwt cstruct lwt lwt.unix mirage-block vhd-format rresult)
+ (libraries bigarray-compat cstruct-lwt cstruct lwt lwt.unix mirage-block unix vhd-format rresult)
  (foreign_stubs
    (language c)
    (names blkgetsize64_stubs lseek64_stubs odirect_stubs)))

--- a/vhd_format_lwt_test/dune
+++ b/vhd_format_lwt_test/dune
@@ -1,5 +1,5 @@
 (test
  (name parse_test)
  (package vhd-format-lwt)
- (libraries alcotest alcotest-lwt cstruct disk io-page fmt lwt lwt.unix vhd-format
+ (libraries alcotest alcotest-lwt cstruct disk io-page fmt lwt lwt.unix unix vhd-format
    vhd_format_lwt))


### PR DESCRIPTION
I've also added explicit dependencies to the unix library, they are asked by OCaml 5.2.0.

Also, the changelog leads to believe that the minimum supported version is 4.10, but this is further limited by the uuidm dependency to 4.14